### PR TITLE
Solve: hy2MhdFoam not found

### DIFF
--- a/run/hyStrath/hy2Foam/NASA_MSL_forebody/NASA_MSL_forebody_R/Allpost
+++ b/run/hyStrath/hy2Foam/NASA_MSL_forebody/NASA_MSL_forebody_R/Allpost
@@ -4,6 +4,6 @@ cd ${0%/*} || exit 1    # run from this directory
 # Source tutorial run functions
 . $WM_PROJECT_DIR/bin/tools/RunFunctions
 
-hy2MhdFoam -postProcess -dict 'system/surfaceCoefficients' -latestTime
+hy2Foam -postProcess -dict 'system/surfaceCoefficients' -latestTime
 
 #runApplication postProcess -func singleGraph -latestTime


### PR DESCRIPTION
Dear contributors,

There is a minor bug in the postprocessing file "Allpost" in the NASA_MSL_forebody cases. From what I have seen so far, hy2Foam has included the magnetohydrodynamics capabilities now, and the hy2MhdFoam module is deprecated.

Best,
Alberto